### PR TITLE
update vite version to avoid XSS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "openapi-typescript-codegen": "^0.25.0",
         "sass": "^1.69.4",
         "typescript": "^5.0.2",
-        "vite": "^4.4.5"
+        "vite": "^4.5.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3409,9 +3409,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
-      "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.18.10",
@@ -5904,9 +5904,9 @@
       "requires": {}
     },
     "vite": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.11.tgz",
-      "integrity": "sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
+      "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "openapi-typescript-codegen": "^0.25.0",
     "sass": "^1.69.4",
     "typescript": "^5.0.2",
-    "vite": "^4.4.5"
+    "vite": "^4.5.1"
   }
 }


### PR DESCRIPTION
"Upgrade vite to version 4.4.12, 4.5.1, 5.0.5 or higher."

https://security.snyk.io/package/npm/vite/4.4.11 

https://github.com/vitejs/vite/blob/v4.5.1/packages/vite/CHANGELOG.md