### PR TITLE
Reinstate navigate state

### DIFF
--- a/src/components/Callback.tsx
+++ b/src/components/Callback.tsx
@@ -35,7 +35,7 @@ export default function Callback() {
         const hashCalculated = await getSHA256Hash(hashBaseString);
         if (hashCalculated === hashURL) {
           await continueRequest();
-        }
+        } else navigate("/");
       } catch {
         console.log("error");
       }

--- a/src/components/Callback.tsx
+++ b/src/components/Callback.tsx
@@ -3,7 +3,6 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { postContinueRequest } from "../apis/gnap/continueRequest";
 import { getSHA256Hash } from "../common/CryptoUtils";
 import { useAppDispatch } from "../hooks";
-import appSlice from "../slices/appReducers";
 import { INTERACTION_RESPONSE, NONCE } from "./../initLocalStorage";
 
 export default function Callback() {
@@ -53,11 +52,11 @@ export default function Callback() {
     if (interactions && interactRef) {
       const response = await dispatch(postContinueRequest({ interactions: interactions, interactRef: interactRef }));
       if (postContinueRequest.fulfilled.match(response)) {
-        navigate("/scim");
-        dispatch(appSlice.actions.setAccessToken(response.payload));
+        navigate("/scim", {
+          state: response.payload,
+        });
       }
     }
   };
-
   return <></>;
 }

--- a/src/components/GroupManagement.tsx
+++ b/src/components/GroupManagement.tsx
@@ -33,9 +33,9 @@ export default function GroupManagement(): JSX.Element {
   const managedAccountsDetails = useAppSelector((state) => state.groups.managedAccounts);
   const membersDetails = useAppSelector((state) => state.members.members);
   const isLoaded = useAppSelector((state) => state.app.isLoaded);
-  const accessTokenState = useAppSelector((state) => state.app.accessToken);
-  const accessToken = accessTokenState?.access_token?.value;
-  const value = accessTokenState?.subject.assertions[0].value;
+  const locationState = location.state;
+  const accessToken = locationState?.access_token?.value;
+  const value = locationState?.subject.assertions[0].value;
   const parsedUserInfo = value ? JSON.parse(value) : null;
 
   useEffect(() => {
@@ -51,10 +51,10 @@ export default function GroupManagement(): JSX.Element {
   }, [membersDetails]);
 
   useEffect(() => {
-    if (accessTokenState === undefined) {
+    if (locationState === undefined) {
       navigate("/");
     }
-  }, [navigate, accessTokenState]);
+  }, [navigate, locationState]);
 
   /**
    * Without user interaction
@@ -206,7 +206,7 @@ export default function GroupManagement(): JSX.Element {
 
   const inputRef = useRef<HTMLInputElement>(null);
 
-  if (accessTokenState === undefined) {
+  if (locationState === undefined) {
     return <></>;
   }
 

--- a/src/components/GroupManagement.tsx
+++ b/src/components/GroupManagement.tsx
@@ -5,7 +5,7 @@ import Personnummer from "personnummer";
 import React, { useEffect, useRef, useState } from "react";
 import { Field, Form } from "react-final-form";
 import { FormattedMessage } from "react-intl";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { GroupMember } from "typescript-clients/scim/models/GroupMember";
 import { createGroup, getGroupDetails, getGroupsSearch, putGroup } from "../apis/scim/groupsRequest";
 import { getUserDetails, postUser } from "../apis/scim/usersRequest";
@@ -28,7 +28,7 @@ interface ErrorsType {
 
 export default function GroupManagement(): JSX.Element {
   const navigate = useNavigate();
-
+  const location = useLocation();
   const dispatch = useAppDispatch();
   const managedAccountsDetails = useAppSelector((state) => state.groups.managedAccounts);
   const membersDetails = useAppSelector((state) => state.members.members);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FormattedMessage } from "react-intl";
 import { useNavigate } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../hooks";
-import appSlice from "../slices/appReducers";
 
 export function Header(): JSX.Element {
   const loggedInUser = useAppSelector((state) => state.personalData.loggedInUser);
@@ -14,8 +13,7 @@ export function Header(): JSX.Element {
   const dispatch = useAppDispatch();
 
   function logout() {
-    navigate("/");
-    dispatch(appSlice.actions.appIsLoaded(false));
+    navigate("/", { replace: true, state: undefined });
   }
 
   if (userMail) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,14 +3,13 @@ import { faArrowRightFromBracket } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { FormattedMessage } from "react-intl";
 import { useNavigate } from "react-router-dom";
-import { useAppDispatch, useAppSelector } from "../hooks";
+import { useAppSelector } from "../hooks";
 
 export function Header(): JSX.Element {
   const loggedInUser = useAppSelector((state) => state.personalData.loggedInUser);
   const userMail = loggedInUser?.user?.attributes?.mail;
   const navigate = useNavigate();
   let logoutButton;
-  const dispatch = useAppDispatch();
 
   function logout() {
     navigate("/", { replace: true, state: undefined });

--- a/src/components/StartSession.tsx
+++ b/src/components/StartSession.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { FormattedMessage } from "react-intl";
 import { useAppDispatch } from "../hooks";
 import { initLocalStorage, INTERACTION_RESPONSE } from "../initLocalStorage";
-import appSlice from "../slices/appReducers";
 import getGroupsSlice from "../slices/getGroups";
 import getPersonalDataSlice from "../slices/getLoggedInUserInfo";
 import getUsersSlice from "../slices/getUsers";
@@ -39,7 +38,6 @@ export function StartSession(): JSX.Element {
     dispatch(getUsersSlice.actions.initialize());
     dispatch(getGroupsSlice.actions.initialize());
     dispatch(getPersonalDataSlice.actions.initialize());
-    dispatch(appSlice.actions.setAccessToken(undefined));
   }, []);
 
   return (

--- a/src/slices/appReducers.ts
+++ b/src/slices/appReducers.ts
@@ -17,12 +17,6 @@ export const appSlice = createSlice({
     appIsLoaded: (state, action) => {
       state.isLoaded = action.payload;
     },
-    setAccessToken: (state, action) => {
-      state.accessToken = action.payload;
-    },
-    saveAccessToken: (state, action) => {
-      state.accessToken = action.payload;
-    },
   },
 });
 


### PR DESCRIPTION
When I changed the method of sending the access token using navigate.state and encountered an issue where the user was redirected to the landing page upon refreshing I reverted to the original method of using navigate.state and clear the navigate.state when the user logout