### PR TITLE
removed access property that contains hardcoded scope in atr: AccessTokenRequest i requestAccess()

### DIFF
--- a/src/apis/gnap/requestAccess.ts
+++ b/src/apis/gnap/requestAccess.ts
@@ -20,7 +20,7 @@ export async function requestAccess(
   redirect_url: string
 ) {
   const atr: AccessTokenRequest = {
-    access: [{ scope: "eduid.docker", type: "scim-api" }],
+    // when "type" is fixed in SCIM it will be "access: [{ type: "scim-api" }],"
     flags: [AccessTokenFlags.BEARER],
   };
 


### PR DESCRIPTION
removed access property that contains hardcoded scope in atr: AccessTokenRequest i requestAccess()